### PR TITLE
Suppress compile time warnings

### DIFF
--- a/ext/certstore/extconf.rb
+++ b/ext/certstore/extconf.rb
@@ -14,7 +14,7 @@ have_library("crypt32")
 have_func("PFXExportCertStoreEx", "Wincrypt.h")
 
 $LDFLAGS << " -lcrypt32"
-$CFLAGS << " -std=c99 -fPIC -fms-extensions "
+$CFLAGS << " -Wall -std=c99 -fPIC -fms-extensions "
 # $CFLAGS << " -g -O0"
 
 create_makefile("certstore/certstore")

--- a/ext/certstore/loader.c
+++ b/ext/certstore/loader.c
@@ -281,7 +281,7 @@ rb_win_certstore_loader_add_certificate(VALUE self, VALUE rb_der_cert_bin_str)
 
   if (CertAddEncodedCertificateToStore(loader->hStore,
                                        X509_ASN_ENCODING,
-                                       RSTRING_PTR(rb_der_cert_bin_str),
+                                       (const BYTE *)RSTRING_PTR(rb_der_cert_bin_str),
                                        RSTRING_LEN(rb_der_cert_bin_str),
                                        CERT_STORE_ADD_NEW,
                                        NULL)) {
@@ -462,7 +462,7 @@ rb_win_certstore_loader_export_pfx(VALUE self, VALUE rb_thumbprint, VALUE rb_pas
   ALLOCV_END(vThumbprint);
   ALLOCV_END(vPassword);
 
-  VALUE rb_str = rb_str_new(pfxPacket.pbData, pfxPacket.cbData);
+  VALUE rb_str = rb_str_new((const char *)pfxPacket.pbData, pfxPacket.cbData);
 
   CryptMemFree(pfxPacket.pbData);
   CertCloseStore(hMemoryStore, CERT_CLOSE_STORE_CHECK_FLAG);

--- a/ext/certstore/loader.c
+++ b/ext/certstore/loader.c
@@ -197,11 +197,6 @@ rb_win_certstore_loader_each_pem(VALUE self)
 static VALUE
 rb_win_certstore_loader_dispose(VALUE self)
 {
-  struct CertstoreLoader* loader;
-
-  TypedData_Get_Struct(
-    self, struct CertstoreLoader, &rb_win_certstore_loader_type, loader);
-
   /* What should we dispose here? */
 
   return Qnil;
@@ -210,13 +205,7 @@ rb_win_certstore_loader_dispose(VALUE self)
 static VALUE
 rb_win_certstore_loader_each(VALUE self)
 {
-  PCCERT_CONTEXT pContext = NULL;
-  struct CertstoreLoader* loader;
-
   RETURN_ENUMERATOR(self, 0, 0);
-
-  TypedData_Get_Struct(
-    self, struct CertstoreLoader, &rb_win_certstore_loader_type, loader);
 
   rb_ensure(
     rb_win_certstore_loader_each_pem, self, rb_win_certstore_loader_dispose, self);


### PR DESCRIPTION
I've added `-Wall` to `CFLAGS` and suppress found warnings.
Although these warnings are harmless, we should clean the build state to highlight actual issues.
